### PR TITLE
Compute Generalized Node Equivalence Classes

### DIFF
--- a/scripts/equivalence.py
+++ b/scripts/equivalence.py
@@ -1,0 +1,97 @@
+#! /usr/bin/python3
+
+
+####
+#  
+#  Compute Node Equivalence Classes for Reachability summaries
+#
+####
+
+import nopticon
+from argparse import ArgumentParser
+
+def height(succ, node, memo):
+    if node not in memo:
+        if node in succ:
+            memo[node] = 1 + max([height(succ, s, memo) for s in succ[node] ])
+        else:
+            memo[node] = 0
+    return memo[node]
+
+    
+def compute_flow_NECs(edges):
+    adj = { source: set([ target for src, target in edges
+                          if src == source])
+            for source,_ in edges }
+    op_adj = { target : set([source for source, tgt in edges
+                             if tgt == target])
+               for _, target in edges }
+
+    # Compute the join of the two key sets
+    nodes = set(adj.keys()).union(set(op_adj.keys()))
+    memo = {}
+    op_memo = {}
+    nec_list = { n: (height(adj, n, memo), height(op_adj, n, op_memo)) for n in nodes }
+    return nec_list
+    
+    
+
+def compute_general_NECs(threshold, reach):
+    all_fNECs = {}
+    for f in reach.get_flows():
+        necs = compute_flow_NECs([edge for edge in reach.get_edges(f).keys()
+                                  if reach.get_edge_rank(f,edge) >= threshold])
+        # print(f,necs)
+        # print()
+        for n, eqc in necs.items():
+            if n in all_fNECs:
+                all_fNECs[n].append((f,eqc))
+            else:
+                all_fNECs[n] = [(f,eqc)]
+
+    for n in all_fNECs.keys():
+        all_fNECs[n] = sorted([eqc for _,eqc in all_fNECs[n]])
+
+    gNECs = set()
+    for n in all_fNECs.keys():
+        for cls in gNECs:
+            if n in cls: #if we've already placed n in an equivalence class
+                continue
+        cls = (n,)
+        for m in all_fNECs.keys():
+            if n != m:
+                if all_fNECs[n] == all_fNECs[m]:
+                    cls += (m,)
+        gNECs.add(tuple(sorted(cls)))
+        
+    return gNECs
+            
+    
+
+
+def main():
+    parser = ArgumentParser(description = "Compute Node Equivalence Classes for a given Reachability Summary and rDNS")
+    parser.add_argument("-t", "--threshold", default=50.0, type=int, required=False,
+                        help="The minimum rank to consider out of 100, e.g. A value of 75 corresponds to a rank of 0.75 ")
+    parser.add_argument("-s", "--sigfigs", default=2, type=int, required=False,
+                        help="The number of sig figs for the rank values")
+    parser.add_argument("summary", help="The filepath to the reachability summary in JSON form")
+    settings = parser.parse_args()
+
+    if settings.threshold > 100:
+        print("Threshold must be between 0 and 100")
+        return 1
+    
+    rs = None
+    
+    with open(settings.summary) as reach_fp:
+        rs = nopticon.ReachSummary(reach_fp.read(), settings.sigfigs)
+        
+    gNECs = compute_general_NECs(float(float(settings.threshold)/100.0), rs)
+
+    # print each equivalence class in
+    for eqC in sorted(gNECs, key = lambda x: x[0]): 
+        print(*eqC)
+        
+if __name__ == "__main__":
+    main()

--- a/scripts/nopticon.py
+++ b/scripts/nopticon.py
@@ -7,8 +7,9 @@ import ipaddress
 import json
 
 class ReachSummary:
-    def __init__(self, summary_json):
+    def __init__(self, summary_json, sigfigs):
         self._summary = json.loads(summary_json)
+        self._sigfigs = sigfigs
 
         # Extract edges
         self._edges = {}
@@ -31,7 +32,7 @@ class ReachSummary:
     def get_edge_rank(self, flow, edge):
         if edge not in self.get_edges(flow):
             return None
-        return self.get_edges(flow)[edge]['rank-0']
+        return round(self.get_edges(flow)[edge]['rank-0'], self._sigfigs)
 
     def get_flows(self):
         return self._edges.keys()


### PR DESCRIPTION
Hi @ahorn and @agember,

Here's a quick python script to compute the Generalized Node Equivalence Classes for our networks as described in our notes from December 5th. I'm using the algorithm described on slide 19.

I've run it on the data I've collected where the rank is defined to be normalized duration. I imagine we would get similar data when the rank is defined in terms of link failures. @agember Is there data for this somewhere?

To run this script, simply type `./equivalence.py <path_to_reach_summary>`. The optional arguments specify the number of `--sigfigs` for the rank, as well as the rank `--threshold` (edges with rank below the threshold are thrown out).

The output that we get is stable for many values of `--sigfig` and `--threshold`, with only extreme values producing very slight differences. The output is also stable across all seeds and for the `fattree-4` topologies and `fattree-4-some-block` topologies. This gives me great confidence in the correctness of this approach.  Here are the equivalence classes produced:

```
AGG*_0 : {agg0_0, agg1_0, agg2_0, agg3_0}
AGG*_1 : {agg0_1, agg1_1, agg2_1, agg3_1}
LEAF* : {leaf0_0, leaf0_1, leaf1_0, leaf2_0, leaf2_1, leaf3_0, leaf3_1}
CORE_ODD : {core1, core3}
CORE2: {core2}
CORE0: {core0}
```  
If you remember, my hypothesis from the slides was that all of the cores would be in the same equivalence class. It turns out the data has a slightly different shape than I expected. Cores `1` and `3` are never waypoints, whereas `core2` is a waypoint to the `leaf*` nodes and `core0` is a waypoint to the `leaf*` nodes and the `agg*` nodes. This incongruity comes from my own incorrect understanding of how the different flows utilized the core nodes, I had expected that their usage would be symmetrically distributed, but in fact their usage is identical for each flow. Below is the list of per-flow equivalence classes for each of the `core*` nodes:

```
core0: [('3.0.0.0/24', (2, 2)), ('3.0.1.0/24', (2, 2)), ('3.2.1.0/24', (2, 2)), ('3.1.1.0/24', (2, 2)), ('3.3.0.0/24', (2, 2)), ('3.1.0.0/24', (2, 2)), ('3.2.0.0/24', (2, 2)), ('3.3.1.0/24', (2, 2))]

core3: [('3.0.0.0/24', (2, 0)), ('3.0.1.0/24', (2, 0)), ('3.2.1.0/24', (2, 0)), ('3.1.1.0/24', (2, 0)), ('3.3.0.0/24', (2, 0)), ('3.1.0.0/24', (2, 0)), ('3.2.0.0/24', (2, 0)), ('3.3.1.0/24', (2, 0))]

core2: [('3.0.0.0/24', (2, 1)), ('3.0.1.0/24', (2, 1)), ('3.2.1.0/24', (2, 1)), ('3.1.1.0/24', (2, 1)), ('3.3.0.0/24', (2, 1)), ('3.1.0.0/24', (2, 1)), ('3.2.0.0/24', (2, 1)), ('3.3.1.0/24', (2, 1))]

core1: [('3.0.0.0/24', (2, 0)), ('3.0.1.0/24', (2, 0)), ('3.2.1.0/24', (2, 0)), ('3.1.1.0/24', (2, 0)), ('3.3.0.0/24', (2, 0)), ('3.1.0.0/24', (2, 0)), ('3.2.0.0/24', (2, 0)), ('3.3.1.0/24', (2, 0))]
```
with the flow information removed this becomes:

```                                                                                                                                   
core0: [(2, 2), (2, 2), (2, 2), (2, 2), (2, 2), (2, 2), (2, 2), (2, 2)]
core1: [(2, 0), (2, 0), (2, 0), (2, 0), (2, 0), (2, 0), (2, 0), (2, 0)]
core2: [(2, 1), (2, 1), (2, 1), (2, 1), (2, 1), (2, 1), (2, 1), (2, 1)]
core3: [(2, 0), (2, 0), (2, 0), (2, 0), (2, 0), (2, 0), (2, 0), (2, 0)]
```

So it seems that `core1` and `core3` do express equivalent behavior, that is quite different from `core0` and `core2`, and it would be _incorrect_ to include them in the same equivalence class as `core1` and `core3`, which gives me further confidence in the correctness of this approach.

Further, despite being written quite naively, the script (including I/O) returns results for `fattree-4` in under a third of a second (which is the typical human response time), the 99% confidence interval (assuming a normal distribution of runtimes) is `[0.1240, 0.1254]` seconds (N=20). Results are computed using the `time` UNIX tool.

Please let me know if you spot anything in the code or in the algorithm or have any questions.

Happy New Years!
Eric